### PR TITLE
2019-08-28 | Auto-restart supervisord on failure

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,8 @@ supervisord_minprocs: 200
 supervisord_umask: "022"
 supervisord_directory: "/tmp"
 supervisord_programs: []
+supervisord_restartop: "on-failure"
+supervisord_startburst: 30
+supervisord_startinterval: 3
+supervisord_starttimeout: 10
+supervisord_stoptimeout: 5

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,20 @@
     owner="root"
     group="root"
 
+- name: Install supervisord systemd script
+  template: 
+    src="supervisord.service.j2"
+    dest="/usr/lib/systemd/system/supervisord.service"
+    mode="0644"
+    owner="root"
+    group="root"
+  register: systemd_script
+
+- name: Issue systemctl daemon-reload
+  systemd:
+    daemon-reload="yes"
+  when: systemd_script is changed
+
 - name: Configure Programs
   template:
     src="program.ini.j2"

--- a/templates/supervisord.service.j2
+++ b/templates/supervisord.service.j2
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+[Unit]
+Description=Process Monitoring and Control Daemon
+After=rc-local.service nss-user-lookup.target
+
+[Service]
+Type=forking
+ExecStart=/usr/bin/supervisord -c /etc/supervisord.conf
+Restart={{ supervisord_restartop }}
+StartLimitInterval={{ supervisord_startinterval }}
+StartLimitBurst={{ supervisord_startburst }}
+TimeoutStartSec={{ supervisord_starttimeout }}
+TimeoutStopSec={{ supervisord_stoptimeout }}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Leveraging off of [Brad's previous pull request](https://github.com/nexcess/ansible-role-supervisord/pull/7) with the following additions: 

- Do not try to restart more than **StartLimitBurst** times within **StartLimitInterval** seconds
- **TimeoutStartSec**: Give the service this many seconds to restart, else it’s considered failed
- **TimeoutStopSec**: Allow the service this many seconds to stop cleanly before considering it failed.
- issue a **systemctl daemon-reload** after updating the script